### PR TITLE
Fix: Saving of the field `locale_detection_strategy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2021-12-17
+
+### Fixed
+
+- Fixed GTM template - the field `locale_detection_strategy` now contains an item `disabled` instead of "noSet" value because of problem with saving in a tag configuration.
+
 ## [0.2.0] - 2021-12-17
 
 ### Added
@@ -72,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The first version of the package has been released.
 
-[unreleased]: https://github.com/68publishers/cookie-consent/compare/v0.2.0...main
+[unreleased]: https://github.com/68publishers/cookie-consent/compare/v0.2.1...main
+[0.2.1]: https://github.com/68publishers/cookie-consent/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/68publishers/cookie-consent/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/68publishers/cookie-consent/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/68publishers/cookie-consent/compare/v0.1.1...v0.1.2

--- a/gtm_template.tpl
+++ b/gtm_template.tpl
@@ -729,12 +729,15 @@ ___TEMPLATE_PARAMETERS___
           {
             "value": "document",
             "displayValue": "Document"
+          },
+          {
+            "value": "disabled",
+            "displayValue": "Disabled"
           }
         ],
         "simpleValueType": true,
         "help": "\"Browser\" to get user\u0027s browser language or \"Document\" to read value from \u0026lt;html lang\u003d\"...\"\u0026gt; of current page.",
-        "defaultValue": "document",
-        "notSetText": "None"
+        "defaultValue": "document"
       },
       {
         "type": "TEXT",
@@ -751,8 +754,8 @@ ___TEMPLATE_PARAMETERS___
         "enablingConditions": [
           {
             "paramName": "locale_detection_strategy",
-            "paramValue": "",
-            "type": "NOT_PRESENT"
+            "paramValue": "disabled",
+            "type": "EQUALS"
           }
         ]
       },
@@ -1102,12 +1105,12 @@ const pluginOptions = {
   cookie_expiration: makeInteger(data.cookie_expiration),
   revision: makeInteger(data.revision),
   delay: makeInteger(data.delay),
-  auto_language: data.hasOwnProperty('locale_detection_strategy') ? data.locale_detection_strategy : null,
+  auto_language: 'disabled' !== data.locale_detection_strategy ? data.locale_detection_strategy : null,
   page_scripts: data.page_scripts
 };
 
 if (data.hasOwnProperty('current_locale')) {
-  pluginOptions.current_locale = data.current_locale;
+  pluginOptions.current_lang = data.current_locale;
 }
 
 if (data.hasOwnProperty('script_selector')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "68publishers-cookie-consent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cookie consent wrapper based on orestbida/cookieconsent with GTM integration.",
   "homepage": "http://www.68publishers.io/",
   "main": "index.js",


### PR DESCRIPTION
Fixed GTM template - the field `locale_detection_strategy` now contains an item `disabled` instead of "noSet" value because of problem with saving in a tag configuration
