### PR TITLE
Added missing translations on GTM template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.6] - 2021-12-21
+
+### Added
+
+- Added options `consent_modal_secondary_btn_settings` and `consent_modal_secondary_btn_accept_necessary` for GTM field `Translations - Key`.
+
 ## [0.2.5] - 2021-12-21
 
 ### Added
@@ -118,7 +126,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The first version of the package has been released.
 
-[unreleased]: https://github.com/68publishers/cookie-consent/compare/v0.2.3...main
+[unreleased]: https://github.com/68publishers/cookie-consent/compare/v0.2.6...main
+[0.2.6]: https://github.com/68publishers/cookie-consent/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/68publishers/cookie-consent/compare/v0.2.4...v0.2.5
+[0.2.4]: https://github.com/68publishers/cookie-consent/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/68publishers/cookie-consent/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/68publishers/cookie-consent/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/68publishers/cookie-consent/compare/v0.2.0...v0.2.1

--- a/gtm_template.tpl
+++ b/gtm_template.tpl
@@ -848,10 +848,6 @@ ___TEMPLATE_PARAMETERS___
                   "displayValue": "consent_modal_primary_btn"
                 },
                 {
-                  "value": "consent_modal_secondary_btn",
-                  "displayValue": "consent_modal_secondary_btn"
-                },
-                {
                   "value": "settings_modal_title",
                   "displayValue": "settings_modal_title"
                 },
@@ -934,6 +930,14 @@ ___TEMPLATE_PARAMETERS___
                 {
                   "value": "modal_trigger_title",
                   "displayValue": "modal_trigger_title"
+                },
+                {
+                  "value": "consent_modal_secondary_btn_settings",
+                  "displayValue": "consent_modal_secondary_btn_settings"
+                },
+                {
+                  "value": "consent_modal_secondary_btn_accept_necessary",
+                  "displayValue": "consent_modal_secondary_btn_accept_necessary"
                 }
               ],
               "simpleValueType": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "68publishers-cookie-consent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Cookie consent wrapper based on orestbida/cookieconsent with GTM integration.",
   "homepage": "http://www.68publishers.io/",
   "main": "index.js",


### PR DESCRIPTION
Added options `consent_modal_secondary_btn_settings` and `consent_modal_secondary_btn_accept_necessary` for GTM field `Translations - Key`.