### PR TITLE
Loading of default translations for locales that are consist of an `I…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default translations are now loaded also for locales that are consist of an `ISO 639-1` language code and an `ISO 3166-1` country code e.g. `en-US`.
+
 ## [0.3.2] - 2021-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The package comes with the default translations for the following languages:
 - [Czech - cs](src/resources/translations/cs.json)
 - [Slovak - sk](src/resources/translations/sk.json)
 
-Translations that will be loaded and accessible for the widget are taken from the field `Locales`. Locale codes are in the format `ISO 639-1` and each locale must be defined on a new line.
+Translations that will be loaded and accessible for the widget are taken from the field `Locales`. Each locale must be defined on a new line.
 If you want to rewrite default translations or you want to add translations for a new locale then you can define them in a table `Translations`.
 
 ### Locale detection

--- a/src/CookieConsentWrapper.js
+++ b/src/CookieConsentWrapper.js
@@ -59,10 +59,11 @@ class CookieConsentWrapper {
     }
 
     loadTranslations(locale) {
+        const localeIso639 = 2 < locale.length ? locale[0] + locale[1] : locale;
         let translations;
 
         try {
-            translations = require(`./resources/translations/${locale}`);
+            translations = require(`./resources/translations/${localeIso639}`);
         } catch (e) {
             translations = {};
         }


### PR DESCRIPTION
…SO 639-1` language code and an `ISO 3166-1` country code