### PR TITLE
Fix Cmp integration

### DIFF
--- a/src/Integration/CmpApiIntegration.js
+++ b/src/Integration/CmpApiIntegration.js
@@ -87,7 +87,7 @@ const integrateCookiesApi = function (wrapper, cmpApiOptions) {
     };
     const headers = [];
 
-    for (let i in cmpApiOptions.cookie_table_headers) {
+    for (let i = 0; i < cmpApiOptions.cookie_table_headers.length; i++) {
         const header = cmpApiOptions.cookie_table_headers[i];
 
         if (!columnMappers.hasOwnProperty(header)) {
@@ -151,11 +151,11 @@ const integrateCookiesApi = function (wrapper, cmpApiOptions) {
 
             const cookieTable = wrapper.cookieTables.getCookieTable(locale);
 
-            for (let i in headers) {
+            for (let i = 0; i < headers.length; i++) {
                 cookieTable.addHeader(headers[i], wrapper.translate(locale, 'cookie_table_col_' + headers[i]));
             }
 
-            for (let i in json.data.cookies) {
+            for (let i = 0; i < json.data.cookies.length; i++) {
                 const cookie = json.data.cookies[i];
                 cookieTable.addRow(cookie.category.code, cookieToRow(cookie, locale));
             }


### PR DESCRIPTION
`for in` iterates over object properties (and prototype chain too) and should not be used to iterate over arrays.

Example: line 90 will make prototype property "remove" child of an array:

![image](https://github.com/68publishers/cookie-consent/assets/62944093/a8d59081-9500-4072-9382-7eb158691df1)
![image](https://github.com/68publishers/cookie-consent/assets/62944093/b53c9dd4-022d-47d8-8ac3-3c2e7f83e3b9)

Tested on Brave Browser - without this fix, I cannot display data from CMP:
![image](https://github.com/68publishers/cookie-consent/assets/62944093/c97fc304-30af-47cc-aea1-31c06f7b6e10)
