### PR TITLE
take into account language-country locale

### DIFF
--- a/src/CookieConsentWrapper.mjs
+++ b/src/CookieConsentWrapper.mjs
@@ -262,7 +262,7 @@ export class CookieConsentWrapper {
             const modalTriggerFactory = new ModalTriggerFactory(document, self._dictionary);
             const modalTriggerElements = modalTriggerFactory.create(
                 self._config.settingsModalOptions.modal_trigger_selector,
-                self._config.pluginOptions.current_lang || document.documentElement.lang,
+                self._config.pluginOptions.current_lang || document.documentElement.lang.split('-')[0],
             );
 
             // re-translate modal trigger


### PR DESCRIPTION
If automatic language detection is enabled and the language is as follow:
```
<html lang="fr-FR" class="js show--consent"></html>
```

Then the language resolves to 'fr-FR' which won't work. This merge request will change the language parsing to take only the language port with the country or regional part. Meaning the language in the exemple above will resolve to 'fr' which is correct