### PR TITLE
Fixed "TypeError: Cannot use 'in' operator to search for 'functionality_storage' in undefined"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed "TypeError: Cannot use 'in' operator to search for 'functionality_storage' in undefined" when no storage is enabled.
 
 ## [1.3.2] - 2025-04-08
 ### Fixed

--- a/src/ConsentManager.mjs
+++ b/src/ConsentManager.mjs
@@ -94,7 +94,7 @@ export class ConsentManager {
         this._gtag('consent', 'update', consent);
 
         if (0 >= accepted.length) {
-            return;
+            return consent;
         }
 
         let eventTriggerKey;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a TypeError that occurred when checking for 'functionality_storage' without any storage enabled.
  - Ensured the consent manager consistently returns the consent object, even when no categories are accepted.

- **Documentation**
  - Updated the changelog to reflect the latest bug fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->