### PR TITLE
Prevented page scrolling after consent has been made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevented page scrolling after consent has been made through a settings modal that was opened through an element created by the "Settings modal trigger selector" option.
 
 ## [1.3.3] - 2025-04-21
 ### Fixed

--- a/src/Ui/ModalTriggerFactory.mjs
+++ b/src/Ui/ModalTriggerFactory.mjs
@@ -45,6 +45,7 @@ export class ModalTriggerFactory {
 
         link.addEventListener('click', event => {
             event.preventDefault();
+            link.blur();
             window.CookieConsentWrapper.unwrap().showSettings(0);
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the page could scroll unexpectedly after giving consent via the settings modal, specifically when opened from a custom trigger element. Focus is now properly removed from the trigger to prevent unwanted scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->