### PR TITLE
Fixed initialization in iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The widget is now not displayed inside iframes if the iframe is displayed on the same origin as the main window. This prevents the widget from being displayed multiple times.
+- The widget will wait for the `DOMContentLoaded` event to occur if `document.body` does not yet exist.
 
 ## [1.4.0] - 2025-06-17
 ### Added

--- a/src/CookieConsentWrapper.mjs
+++ b/src/CookieConsentWrapper.mjs
@@ -379,7 +379,7 @@ export class CookieConsentWrapper {
 
         let initPromise = null;
 
-        if (!this._config.pluginOptions.init_after_dom_content_loaded) {
+        if (!this._config.pluginOptions.init_after_dom_content_loaded && document.body) {
             initPromise = doInitCookieConsent();
         }
 

--- a/src/CookieConsentWrapperFactory.mjs
+++ b/src/CookieConsentWrapperFactory.mjs
@@ -39,9 +39,24 @@ export class CookieConsentWrapperFactory {
             },
         }
 
-        cookieConsentWrapper.init(window, document);
+        if (this.#shouldInit()) {
+            cookieConsentWrapper.init(window, document);
+        }
+
 
         return cookieConsentWrapper;
+    }
+
+    #shouldInit() {
+        try {
+            if (window.self === window.top) {
+                return true;
+            }
+
+            return !window.top.location.hostname;
+        } catch (e) { // eslint-disable-line no-unused-vars
+            return true;
+        }
     }
 
     #createGtagFunction() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the widget from displaying inside iframes that share the same origin as the main window, avoiding multiple instances.
  * Deferred widget initialization until the page is fully loaded if necessary, ensuring proper display and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->